### PR TITLE
fixed version sort

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -16,7 +16,7 @@ curl_opts=(-fsSL)
 
 sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+    LC_ALL=C sort -t "." -k1,1n -k2,2n -k3,3V -k1.1,1.1 | awk '{print $2}'
 }
 
 list_github_tags() {


### PR DESCRIPTION
The `helix` repo switched their tags' naming convention from `v$semver` to `$major.$minor`: https://github.com/helix-editor/helix/releases/tag/24.07

This results in the old convention being listed last:

```console
% mise install helix
curl: (56) The requested URL returned error: 404
mise ERROR ~/.local/share/mise/plugins/helix/bin/download failed
* Downloading helix release 0.6.0...
curl: (56) The requested URL returned error: 404
asdf-helix: Could not download https://github.com/helix-editor/helix/releases/download/0.6.0/helix-0.6.0-aarch64-macos.tar.xz
mise ERROR failed to install https://github.com/cvirtucio/asdf-helix#version-sort-fix@0.6.0
mise ERROR ~/.local/share/mise/plugins/helix/bin/download exited with non-zero status: exit code 1
```

This PR fixes the sort, such that the old convention is listed first, and the new convention is listed last:

```console
% MISE_LIBGIT2=false mise plugins add helix "git@github.com:cvirtucio/asdf-helix.git#version-sort-fix"
mise plugin:helix          ✓ git@github.com:cvirtucio/asdf-helix.git#8e3b08b
% mise install
mise helix@24.07           ✓ installed
```
